### PR TITLE
fix(ci): upgrade CodeQL checkout to actions/checkout@v6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         language: ['javascript-typescript']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
Node.js 20 actions deprecated; forced to Node 24 starting June 16, 2026. Single-line change in codeql.yml.